### PR TITLE
fix client deployment

### DIFF
--- a/.semaphore/client-deploy-build.yml
+++ b/.semaphore/client-deploy-build.yml
@@ -53,6 +53,7 @@ blocks:
 
             # Copy production configs we linked using secrets
             - cp /home/semaphore/client-production.env .env
+            - source ./.env
 
             # Restore dependencies from cache.
             # For more info on caching, see https://docs.semaphoreci.com/article/68-caching-dependencies

--- a/.semaphore/client-deploy.yml
+++ b/.semaphore/client-deploy.yml
@@ -10,12 +10,9 @@ agent:
 blocks:
   - name: Build
     task:
-      # Mount a secret which defines /home/semaphore/.kube/gc-k8s.yaml.
-      # By mounting it, we make file available in the job environment.
       # For info on creating secrets, see:
       # https://docs.semaphoreci.com/article/66-environment-variables-and-secrets
       secrets:
-        - name: gc-k8s-secret
         - name: gcr-secret
       jobs:
         - name: Deploy to Google Cloud Storage

--- a/.semaphore/server-deploy-k8s.yml
+++ b/.semaphore/server-deploy-k8s.yml
@@ -8,18 +8,16 @@ agent:
 blocks:
   - name: Deploy server to Kubernetes
     task:
-      # Mount a secret which defines /home/semaphore/.kube/gc-k8s.yaml.
-      # By mounting it, we make file available in the job environment.
       # For info on creating secrets, see:
       # https://docs.semaphoreci.com/article/66-environment-variables-and-secrets
       secrets:
-        - name: gc-k8s-secret
         - name: gcr-secret
 
-      # Define an environment variable which configures kubectl:
+      # Set environment variables that your project requires.
+      # See https://docs.semaphoreci.com/article/66-environment-variables-and-secrets
       env_vars:
-        - name: KUBECONFIG
-          value: /home/semaphore/.kube/gc-k8s.yaml
+        - name: CLUSTER_NAME
+          value: semaphore-demo-javascript-server
       prologue:
         commands:
           # Authenticate using the file injected from the secret
@@ -28,6 +26,8 @@ blocks:
           - gcloud auth configure-docker -q
           - gcloud config set project $GCP_PROJECT_ID
           - gcloud config set compute/zone $GCP_PROJECT_DEFAULT_ZONE
+          # Get kubectl config file
+          - gcloud container clusters get-credentials $CLUSTER_NAME --zone $GCP_PROJECT_DEFAULT_ZONE --project $GCP_PROJECT_ID
           - checkout
           - cd src/server
       jobs:


### PR DESCRIPTION
The React client is not connecting properly to the API server. This is because an environment file is not being sourced before "npm run build".  This patch fixes the issue.

I also found that we can safely remove one secret: "gc-k8s-secret" which contains the kubeconfig. We can get this file directly in the pipeline using "gcloud". I removed the secret and the KUBECONFIG environment. I had to add the CLUSTER_NAME environment variable to identify the Kubernetes cluster.

I think removing a secret simplifies the setup, the user no longer needs to install gcloud in his dev machine just to get the kubeconfig. It also simplifies explaining the demo in the tutorial.

I tested the whole app: client+server in google cloud with this branch and it works.

![react](https://user-images.githubusercontent.com/46322567/60938738-735b9580-a2ab-11e9-88c2-005be759a342.png)
