### PR TITLE
remove unneeded command

### DIFF
--- a/.semaphore/client-deploy.yml
+++ b/.semaphore/client-deploy.yml
@@ -24,8 +24,6 @@ blocks:
           commands:
             # Authenticate using the file injected from the secret
             - gcloud auth activate-service-account --key-file=.secrets.gcp.json
-            # Don't forget -q to silence confirmation prompts
-            - gcloud auth configure-docker -q
             - gcloud config set project $GCP_PROJECT_ID
             - gcloud config set compute/zone $GCP_PROJECT_DEFAULT_ZONE
 


### PR DESCRIPTION
Remove "gcloud docker" command from the client deployment pipeline.